### PR TITLE
feat: add authentication endpoint

### DIFF
--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -44,6 +44,10 @@ export type {
   OptionalAccountToken,
   IOAuthToken,
   IOAuthTokenResult,
+  IPlatformToken,
+  IPlatformTokenResult,
+  IPlatformUserToken,
+  IPlatformUserTokenResult,
   AllowedCustomizations,
   DefaultCustomizations,
   WithCommonOptions

--- a/packages/sdk-core/src/interfaces/Token.ts
+++ b/packages/sdk-core/src/interfaces/Token.ts
@@ -34,4 +34,20 @@ export interface IOAuthToken {
   created_at: number
 }
 
+export interface IPlatformToken {
+  access_token: string
+  token_type: 'Bearer'
+  expires_in: number
+  scope: string
+  created_at: number
+}
+
+export interface IPlatformUserToken extends IPlatformToken {
+  refresh_token: string
+}
+
 export interface IOAuthTokenResult extends ResultResponse<IOAuthToken> {}
+
+export interface IPlatformTokenResult extends ResultResponse<IPlatformToken> {}
+
+export interface IPlatformUserTokenResult extends ResultResponse<IPlatformUserToken> {}

--- a/packages/sdk-platform/src/endpoints/Authentication.ts
+++ b/packages/sdk-platform/src/endpoints/Authentication.ts
@@ -1,0 +1,136 @@
+import {
+  Http,
+  squashAndPreparePositionalArguments
+} from '@spree/core-api-v2-sdk'
+import type {
+  IPlatformToken,
+  IPlatformTokenResult,
+  IPlatformUserToken,
+  IPlatformUserTokenResult
+} from '@spree/core-api-v2-sdk'
+import type {
+  AuthApplicationTokenAttr,
+  AuthUserTokenAttr,
+  AuthRefreshTokenAttr,
+  GetApplicationTokenOptions,
+  GetUserTokenOptions,
+  RefreshTokenOptions
+} from '../interfaces/Authentication'
+import {
+  applicationAuthParams,
+  userAuthParams,
+  refreshParams
+} from '../helpers/auth'
+import routes from '../routes'
+
+export default class Authentication extends Http {
+  /**
+   * Creates a [Bearer token](../pages/tokens.html#bearer-token) required to authorize Platform API calls using application credentials.
+   * 
+   * **Success response schema:**
+   * ```ts
+   * interface res {
+   *   access_token: string
+   *   token_type: string = 'Bearer'
+   *   expires_in: number
+   *   scope: string
+   *   created_at: number
+   * }
+   * ```
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const token = await client.authentication.getApplicationToken({
+   *   client_id: '7ZY15L7crVZul8i3PZPrnpOkEURK7xnXEWRZdE6K39M',
+   *   client_secret: 'cxMZ0tbe604qj_13hibNmc3GDsXUQfpzHt9PvweihFc'
+   * })
+   * ```
+   */
+  public async getApplicationToken(options: GetApplicationTokenOptions): Promise<IPlatformTokenResult> {
+    const { token, params } = squashAndPreparePositionalArguments([options], [])
+
+    return await this.spreeResponse<IPlatformToken>(
+      'post',
+      routes.oauthTokenPath(),
+      token,
+      applicationAuthParams(params as AuthApplicationTokenAttr)
+    )
+  }
+
+  /**
+   * Creates a [Bearer token](../pages/tokens.html#bearer-token) required to authorize Platform API calls using user credentials.
+   * 
+   * **Success response schema:**
+   * ```ts
+   * interface res {
+   *   access_token: string
+   *   token_type: string = 'Bearer'
+   *   expires_in: number
+   *   refresh_token: string
+   *   scope: string
+   *   created_at: number
+   * }
+   * ```
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const token = await client.authentication.getUserToken({
+   *   client_id: '7ZY15L7crVZul8i3PZPrnpOkEURK7xnXEWRZdE6K39M',
+   *   client_secret: 'cxMZ0tbe604qj_13hibNmc3GDsXUQfpzHt9PvweihFc',
+   *   username: 'spree@example.com',
+   *   password: 'spree123'
+   * })
+   * ```
+   */
+  public async getUserToken(options: GetUserTokenOptions): Promise<IPlatformUserTokenResult> {
+    const { token, params } = squashAndPreparePositionalArguments([options], [])
+
+    return await this.spreeResponse<IPlatformUserToken>(
+      'post',
+      routes.oauthTokenPath(),
+      token,
+      userAuthParams(params as AuthUserTokenAttr)
+    )
+  }
+
+  /**
+   * Refreshes the [Bearer token](../pages/tokens.html#bearer-token) required to authorize OAuth API calls.
+   * 
+   * **Success response schema:**
+   * ```ts
+   * interface res {
+   *   access_token: string
+   *   token_type: string = 'Bearer'
+   *   expires_in: number
+   *   refresh_token: string
+   *   scope: string
+   *   created_at: number
+   * }
+   * ```
+   * 
+   * **Failure response schema:** [Error schema](../pages/response-schema.html#error-schema)
+   * 
+   * **Example:**
+   * ```ts
+   * const token = await client.authentication.refreshUserToken({
+   *   refresh_token: 'aebe2886d7dbba6f769e20043e40cfa3447e23ad9d8e82c632f60ed63a2f0df1'
+   * })
+   * ```
+   */
+  public async refreshUserToken(options: RefreshTokenOptions): Promise<IPlatformUserTokenResult> {
+    const { token, params } = squashAndPreparePositionalArguments([options], [])
+
+    console.log(refreshParams(params as AuthRefreshTokenAttr));
+
+    return await this.spreeResponse<IPlatformUserToken>(
+      'post',
+      routes.oauthTokenPath(),
+      token,
+      refreshParams(params as AuthRefreshTokenAttr)
+    )
+  }
+}

--- a/packages/sdk-platform/src/endpoints/index.ts
+++ b/packages/sdk-platform/src/endpoints/index.ts
@@ -1,5 +1,6 @@
 import Addresses from './Addresses'
 import Adjustments from './Adjustments'
+import Authentication from './Authentication'
 import Classifications from './Classifications'
 import Countries from './Countries'
 import Pages from './Pages'
@@ -44,6 +45,7 @@ import Zones from './Zones'
 export {
   Addresses,
   Adjustments,
+  Authentication,
   Classifications,
   Countries,
   Pages,

--- a/packages/sdk-platform/src/helpers/auth.ts
+++ b/packages/sdk-platform/src/helpers/auth.ts
@@ -1,0 +1,34 @@
+import {
+  AuthApplicationTokenAttr,
+  AuthApplicationTokenParams,
+  AuthUserTokenAttr,
+  AuthUserTokenParams,
+  AuthRefreshTokenAttr,
+  AuthRefreshTokenParams
+} from '../interfaces/Authentication'
+
+export const applicationAuthParams = ({ client_id, client_secret }: AuthApplicationTokenAttr): AuthApplicationTokenParams => ({
+  client_id,
+  client_secret,
+  grant_type: 'client_credentials',
+  scope: 'admin'
+})
+
+export const userAuthParams = ({
+  client_id,
+  client_secret,
+  username,
+  password
+}: AuthUserTokenAttr): AuthUserTokenParams => ({
+  client_id,
+  client_secret,
+  username,
+  password,
+  grant_type: 'password',
+  scope: 'admin'
+})
+
+export const refreshParams = ({ refresh_token }: AuthRefreshTokenAttr): AuthRefreshTokenParams => ({
+  refresh_token,
+  grant_type: 'refresh_token'
+})

--- a/packages/sdk-platform/src/interfaces/Authentication.ts
+++ b/packages/sdk-platform/src/interfaces/Authentication.ts
@@ -1,0 +1,42 @@
+import { WithCommonOptions } from '@spree/core-api-v2-sdk'
+
+export interface AuthApplicationTokenAttr {
+  client_id: string
+  client_secret: string
+}
+
+export interface AuthUserTokenAttr extends AuthApplicationTokenAttr {
+  username: string
+  password: string
+}
+
+export interface AuthRefreshTokenAttr {
+  refresh_token: string
+}
+
+export interface AuthApplicationTokenParams {
+  grant_type: 'client_credentials'
+  scope: 'admin'
+  client_id: string
+  client_secret: string
+}
+
+export interface AuthUserTokenParams {
+  grant_type: 'password'
+  scope: 'admin'
+  client_id: string
+  client_secret: string
+  username: string
+  password: string
+}
+
+export interface AuthRefreshTokenParams {
+  grant_type: 'refresh_token'
+  refresh_token: string
+}
+
+export type GetApplicationTokenOptions = WithCommonOptions<null, AuthApplicationTokenAttr>
+
+export type GetUserTokenOptions = WithCommonOptions<null, AuthUserTokenAttr>
+
+export type RefreshTokenOptions = WithCommonOptions<null, AuthRefreshTokenAttr>

--- a/packages/sdk-platform/src/makeClient.ts
+++ b/packages/sdk-platform/src/makeClient.ts
@@ -3,6 +3,7 @@ import type { IClientConfig } from '@spree/core-api-v2-sdk'
 import {
   Addresses,
   Adjustments,
+  Authentication,
   Classifications,
   Countries,
   Pages,
@@ -48,6 +49,7 @@ import {
 const endpoints = {
   addresses: Addresses,
   adjustments: Adjustments,
+  authentication: Authentication,
   classifications: Classifications,
   countries: Countries,
   pages: Pages,

--- a/packages/sdk-platform/src/routes.ts
+++ b/packages/sdk-platform/src/routes.ts
@@ -1,6 +1,7 @@
 export const platformPath = `api/v2/platform`
 
 const endpoints = {
+  oauthTokenPath: (): string => `spree_oauth/token`,
   addressesPath: (): string => `${platformPath}/addresses`,
   addressPath: (id: string): string => `${platformPath}/addresses/${encodeURIComponent(id)}`,
   adjustmentsPath: (): string => `${platformPath}/adjustments`,


### PR DESCRIPTION
This PR adds authentication endpoint for managing tokens - [docs](https://api.spreecommerce.org/docs/api-v2/d014178e4ee93-create-or-refresh-a-token).