### PR TITLE
fix: arguments merge function

### DIFF
--- a/packages/sdk-core/src/helpers/squashAndPreparePositionalArguments.ts
+++ b/packages/sdk-core/src/helpers/squashAndPreparePositionalArguments.ts
@@ -26,6 +26,7 @@ export const squashAndPreparePositionalArguments = (
   // It replicates the order of arguments for endpoints methods.
   const mergedArguments: Record<string, any> = Object.assign({},
     ...[...positionalArguments] // make a copy of the original array (for reverse)
+      .filter(Boolean)
       .map(x =>
         Object.keys(x).filter(key => x[key]) // remove empty props from objects
           .reduce((ac, a) => ({ ...ac, [a]: x[a] }), {}) // turn array into object with props

--- a/packages/sdk-core/src/helpers/squashAndPreparePositionalArguments.ts
+++ b/packages/sdk-core/src/helpers/squashAndPreparePositionalArguments.ts
@@ -24,7 +24,14 @@ export const squashAndPreparePositionalArguments = (
 ): Record<string, any> & { token: IToken } & { params: Record<string, any> } => {
   // Using reverse() ensures we treat the first object with priority.
   // It replicates the order of arguments for endpoints methods.
-  const mergedArguments: Record<string, any> = Object.assign({}, ...positionalArguments.filter(Boolean).reverse())
+  const mergedArguments: Record<string, any> = Object.assign({},
+    ...[...positionalArguments] // make a copy of the original array (for reverse)
+      .map(x =>
+        Object.keys(x).filter(key => x[key]) // remove empty props from objects
+          .reduce((ac, a) => ({ ...ac, [a]: x[a] }), {}) // turn array into object with props
+      ).filter(x => Object.keys(x).length) // filter out empty objects
+      .reverse()
+  )
   const [restArguments, tokensArguments] = split(mergedArguments, [
     'order_token',
     'bearer_token',


### PR DESCRIPTION
This PR fixes the filter of empty objects and adds a filter for objects with falsy props to the `squashAndPreparePositionalArguments` function. The lack of them caused an error when calling the `account.completedOrder` endpoint. When provided with the following array:
```js
[
  { order_number: undefined },
  {
    bearer_token: '...',
    order_number: 'R285427148',
    include: '...'
  },
  {}
]
```
The merge function would overwrite `order_number` to undefined instead of assigning the valid `R285427148`.

This might have possibly caused similar errors in other endpoints that use the new SDK's `options` interface.