### PR TITLE
fix: bundle core type definitions for @spree/storefront-api-v2-sdk

### DIFF
--- a/Dockerfile.test-runtime
+++ b/Dockerfile.test-runtime
@@ -1,4 +1,4 @@
-FROM node:14.15.4
+FROM node:14.18.3
 
 WORKDIR /sdk
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,6 +1802,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "dev": true,
@@ -2514,6 +2528,18 @@
       "version": "2.3.9",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/marked": {
       "version": "4.2.3",
@@ -5476,6 +5502,57 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
+      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.3.0.tgz",
+      "integrity": "sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.0"
+      },
+      "engines": {
+        "node": ">=v14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.18.6"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0",
+        "typescript": "^4.1 || ^5.0"
+      }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -6439,6 +6516,8 @@
         "node-fetch": "^2.6.7",
         "prettier": "^2.3.2",
         "progress-bar-webpack-plugin": "^2.1.0",
+        "rollup": "^3.20.2",
+        "rollup-plugin-dts": "^5.3.0",
         "source-map-loader": "^2.0.2",
         "ts-loader": "^8.3.0",
         "typescript": "^4.5.2",
@@ -6740,6 +6819,8 @@
         "node-fetch": "^2.6.7",
         "prettier": "^2.3.2",
         "progress-bar-webpack-plugin": "^2.1.0",
+        "rollup": "^3.20.2",
+        "rollup-plugin-dts": "^5.3.0",
         "source-map-loader": "^2.0.2",
         "ts-loader": "^8.3.0",
         "typescript": "^4.5.2",
@@ -7690,6 +7771,13 @@
       "version": "1.0.0",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "dev": true
@@ -8116,6 +8204,15 @@
     "lunr": {
       "version": "2.3.9",
       "dev": true
+    },
+    "magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      }
     },
     "marked": {
       "version": "4.2.3",
@@ -10042,6 +10139,37 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
+      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-dts": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.3.0.tgz",
+      "integrity": "sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "magic-string": "^0.30.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@babel/highlight": "^7.18.6"
+          }
+        }
       }
     },
     "run-parallel": {

--- a/packages/sdk-core/tsconfig.json
+++ b/packages/sdk-core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["dom", "es2016"],
     "moduleResolution": "node",
     "noUnusedParameters": true,
     "sourceMap": true,
@@ -9,6 +10,8 @@
     "esModuleInterop": true,
     "declaration": true,
     "declarationDir": "./types",
-    "importsNotUsedAsValues": "preserve"
+    "importsNotUsedAsValues": "preserve",
+    "composite": true,
+    "rootDir": "src"
   }
 }

--- a/packages/sdk-core/webpack.config.mjs
+++ b/packages/sdk-core/webpack.config.mjs
@@ -17,6 +17,7 @@ export default {
   context: baseDirectoryPath,
   plugins: [
     new ProgressBar(),
+    new DeleteBeforeRun(resolve(baseDirectoryPath, 'dist')),
     new DeleteBeforeRun(resolve(baseDirectoryPath, 'types')),
     new WatchIgnorePlugin({ paths: [resolve(baseDirectoryPath, 'types')] }),
   ],

--- a/packages/sdk-storefront/package.json
+++ b/packages/sdk-storefront/package.json
@@ -6,11 +6,13 @@
     "node": ">=14.17.0"
   },
   "main": "dist/server/index.js",
-  "types": "types/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "webpack",
     "build:server": "webpack --config-name server",
     "build:client": "webpack --config-name client",
+    "build:types": "rollup -c",
+    "postbuild": "npm run build:types",
     "watch": "webpack --watch",
     "watch:server": "webpack --watch --config-name server",
     "watch:client": "webpack --watch --config-name client",
@@ -40,6 +42,8 @@
     "node-fetch": "^2.6.7",
     "prettier": "^2.3.2",
     "progress-bar-webpack-plugin": "^2.1.0",
+    "rollup": "^3.20.2",
+    "rollup-plugin-dts": "^5.3.0",
     "source-map-loader": "^2.0.2",
     "ts-loader": "^8.3.0",
     "typescript": "^4.5.2",

--- a/packages/sdk-storefront/rollup.config.mjs
+++ b/packages/sdk-storefront/rollup.config.mjs
@@ -1,0 +1,9 @@
+import dts from 'rollup-plugin-dts'
+
+export default {
+  input: './types/index.d.ts',
+  output: [{ file: 'dist/index.d.ts', format: 'es' }],
+  plugins: [dts({
+    respectExternal: true
+  })],
+}

--- a/packages/sdk-storefront/src/makeClient.ts
+++ b/packages/sdk-storefront/src/makeClient.ts
@@ -32,6 +32,10 @@ const endpoints = {
   wishlists: Wishlists
 }
 
-const makeClient = (config: IClientConfig): Client => new Client(config, endpoints)
+type Endpoints = {
+  [key in keyof typeof endpoints]: InstanceType<typeof endpoints[key]>
+}
+
+const makeClient = (config: IClientConfig): Client & Endpoints => new Client(config, endpoints) as Client & Endpoints
 
 export default makeClient

--- a/packages/sdk-storefront/tsconfig.json
+++ b/packages/sdk-storefront/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
+    "lib": ["dom", "es2016"],
     "noUnusedParameters": true,
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
@@ -9,5 +10,8 @@
     "declaration": true,
     "declarationDir": "./types",
     "importsNotUsedAsValues": "preserve"
-  }
+  },
+  "references": [
+    { "path": "./../sdk-core" }
+  ]
 }

--- a/packages/sdk-storefront/webpack.common.maker.mjs
+++ b/packages/sdk-storefront/webpack.common.maker.mjs
@@ -15,6 +15,7 @@ export default ({ typeScriptConfigFilePath }) => ({
   context: baseDirectoryPath,
   plugins: [
     new ProgressBar(),
+    new DeleteBeforeRun(resolve(baseDirectoryPath, 'dist')),
     new DeleteBeforeRun(resolve(baseDirectoryPath, 'types')),
     new WatchIgnorePlugin({ paths: [resolve(baseDirectoryPath, 'types')] })
   ],


### PR DESCRIPTION
## Description
This PR reconfigures the build process of `@spree/storefront-api-v2-sdk` package to correctly include all of the required type definitions. In the process of splitting up the sdk into multiple monorepo packages the common classes and types for `storefront sdk` and `platform sdk` have been extracted to the `core` package.

During the build process of `storefront sdk` all of the core components were bundled and exported correctly making it fully functional. However, the type definition files (`.d.ts`) were not including the generated core type definitions (from the `core` package). This resulted in the lack of IDE type suggestions while using the sdk.

## Solution
To correctly reflect the typings relationships between packages during development, the Typescript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) had to be configured.

To include type definitions from another package some sort of bundler has to be configured that will resolve all the imports and put them together into a final bundle. All the webpack plugins that handle that are not being supported anymore. There is also a tool called `dts-bundle-generator` that looked promising but the issue with it is that it doesn't handle name collision of types. In different parts of the sdk we have types that have the same name and they don't collide with each other unless they are placed a single file. We would have to rename all the types to be globally unique.

Contrary to webpack, rollup seems to have a bigger ecosystem of packages for doing this kind of tasks. It has a [rollup-plugin-dts](https://www.npmjs.com/package/rollup-plugin-dts) package that is being actively maintained. I decided to use it despite the fact that our build process is based on webpack.

Now the final type definitions bundle (`dist/index.d.ts`) includes all the type definitions of `sdk-storefront` and `sdk-core` packages.