### PR TITLE
fix: define types versions covering all import options

### DIFF
--- a/packages/sdk-platform/package.json
+++ b/packages/sdk-platform/package.json
@@ -5,8 +5,13 @@
   "engines": {
     "node": ">=14.17.0"
   },
-  "main": "dist/server/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/server/index.js",
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "dist/*": ["./dist/index.d.ts"]
+    }
+  },
   "scripts": {
     "build": "webpack",
     "build:server": "webpack --config-name server",

--- a/packages/sdk-storefront/package.json
+++ b/packages/sdk-storefront/package.json
@@ -5,8 +5,13 @@
   "engines": {
     "node": ">=14.17.0"
   },
-  "main": "dist/server/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/server/index.js",
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "dist/*": ["./dist/index.d.ts"]
+    }
+  },
   "scripts": {
     "build": "webpack",
     "build:server": "webpack --config-name server",


### PR DESCRIPTION
## Description
This PR adds `typesVersions` property to `package.json` files of `storefront sdk` and `platform sdk` that points to the same type definitions for all `/dist/...` imports.

Before, only importing the sdks by name included type definitions:
```ts
import { makeClient } from '@spree/storefront-api-v2-sdk';
```
While specifying an explicit path didn't, resulting in a "Cannot find module ... or its corresponding type declarations" error:
```ts
import { makeClient } from '@spree/storefront-api-v2-sdk/dist/server';
// or
import { makeClient } from '@spree/storefront-api-v2-sdk/dist/server/index';
```
This issue was also present in `v5.1.6` of the storefront sdk (before we started splitting up the project into multiple packages).
