### PR TITLE
fix: redefine Client type merged with attached endpoints

### DIFF
--- a/packages/sdk-platform/src/index.ts
+++ b/packages/sdk-platform/src/index.ts
@@ -1,6 +1,7 @@
 export * from '@spree/core-api-v2-sdk'
 import routes, { platformPath } from './routes'
 import * as endpoints from './endpoints'
-import makeClient from './makeClient'
+import makeClient, { Client, Endpoints } from './makeClient'
 
 export { makeClient, endpoints, routes, platformPath }
+export type { Client, Endpoints }

--- a/packages/sdk-platform/src/makeClient.ts
+++ b/packages/sdk-platform/src/makeClient.ts
@@ -1,4 +1,4 @@
-import { Client } from '@spree/core-api-v2-sdk'
+import { Client as CoreClient } from '@spree/core-api-v2-sdk'
 import type { IClientConfig } from '@spree/core-api-v2-sdk'
 import {
   Addresses,
@@ -95,7 +95,9 @@ const endpoints = {
 type Endpoints = {
   [key in keyof typeof endpoints]: InstanceType<typeof endpoints[key]>
 }
+type Client = CoreClient & Endpoints
 
-const makeClient = (config: IClientConfig): Client & Endpoints => new Client(config, endpoints) as Client & Endpoints
+const makeClient = (config: IClientConfig): Client => new CoreClient(config, endpoints) as Client
 
+export type { Client, Endpoints }
 export default makeClient

--- a/packages/sdk-storefront/src/index.ts
+++ b/packages/sdk-storefront/src/index.ts
@@ -1,9 +1,10 @@
 export * from '@spree/core-api-v2-sdk'
 import routes, { storefrontPath } from './routes'
 import * as endpoints from './endpoints'
-import makeClient from './makeClient'
+import makeClient, { Client, Endpoints } from './makeClient'
 
 export { makeClient, endpoints, routes, storefrontPath }
+export type { Client, Endpoints }
 
 export type {
   Fetcher,

--- a/packages/sdk-storefront/src/makeClient.ts
+++ b/packages/sdk-storefront/src/makeClient.ts
@@ -1,4 +1,4 @@
-import { Client } from '@spree/core-api-v2-sdk'
+import { Client as CoreClient } from '@spree/core-api-v2-sdk'
 import type { IClientConfig } from '@spree/core-api-v2-sdk'
 import {
   Account,
@@ -35,7 +35,9 @@ const endpoints = {
 type Endpoints = {
   [key in keyof typeof endpoints]: InstanceType<typeof endpoints[key]>
 }
+type Client = CoreClient & Endpoints
 
-const makeClient = (config: IClientConfig): Client & Endpoints => new Client(config, endpoints) as Client & Endpoints
+const makeClient = (config: IClientConfig): Client => new CoreClient(config, endpoints) as Client
 
+export type { Client, Endpoints }
 export default makeClient


### PR DESCRIPTION
## Description
This PR redefines the `Client` type to include the endpoints that the `storefront` or `platform` sdks define. That type is then being exported as `Client` type instead of the `Client` from the `core` package.

That is because VueStorefront uses the `Client` type in its type definitions and it needs to have the endpoints included - having it inferred from the `makeClient` function is not enough.