### PR TITLE
fix: add explicit platform interfaces exports for response types

### DIFF
--- a/packages/sdk-platform/src/index.ts
+++ b/packages/sdk-platform/src/index.ts
@@ -5,3 +5,399 @@ import makeClient, { Client, Endpoints } from './makeClient'
 
 export { makeClient, endpoints, routes, platformPath }
 export type { Client, Endpoints }
+
+export type {
+  Fetcher,
+  CreateFetcher,
+  CreateFetcherConfig,
+  FetcherConfig,
+  IClientConfig,
+  CreateFetchFetcherConfig,
+  CreateCustomizedFetchFetcher,
+  DeepAnyObject,
+  EmptyObjectResponse,
+  EmptyObjectResult,
+  FieldErrors,
+  Errors,
+  ErrorType,
+  HttpMethod,
+  AutomaticResponseParsing,
+  ResponseParsing,
+  FetchConfig,
+  ImageTransformation,
+  JsonApiDocument,
+  JsonApiResponse,
+  JsonApiListResponse,
+  JsonApiSingleResponse,
+  NoContentResponse,
+  NoContentResult,
+  IQuery,
+  IProductsQuery,
+  RawFetchRequest,
+  RawFetchResponse,
+  RelationType,
+  IRelationships,
+  Result,
+  ResultResponse,
+  IToken,
+  RequiredAnyToken,
+  OptionalAnyToken,
+  RequiredAccountToken,
+  OptionalAccountToken,
+  IOAuthToken,
+  IOAuthTokenResult,
+  AllowedCustomizations,
+  DefaultCustomizations,
+  WithCommonOptions
+} from '@spree/core-api-v2-sdk'
+
+export type {
+  AddressAttr,
+  AddressData,
+  IAddress,
+  IAddresses,
+  IAddressResult,
+  IAddressesResult
+} from './interfaces/Addresses'
+export type {
+  AdjustmentAttr,
+  AdjustmentData,
+  IAdjustment,
+  IAdjustments,
+  IAdjustmentResult,
+  IAdjustmentsResult
+} from './interfaces/Adjustments'
+export type {
+  AuthApplicationTokenAttr,
+  AuthUserTokenAttr,
+  AuthRefreshTokenAttr
+} from './interfaces/Authentication'
+export type {
+  ClassificationAttr,
+  ClassificationData,
+  IClassification,
+  IClassifications,
+  IClassificationResult,
+  IClassificationsResult
+} from './interfaces/Classifications'
+export type {
+  CountriesAttr,
+  CountryData,
+  ICountry,
+  ICountries,
+  ICountryResult,
+  ICountriesResult
+} from './interfaces/Countries'
+export type {
+  DigitalAsset,
+  DigitalAssetResult
+} from './interfaces/DigitalAsset'
+export type {
+  DigitalAttr,
+  DigitalData,
+  IDigital,
+  IDigitals,
+  IDigitalResult,
+  IDigitalsResult
+} from './interfaces/Digitals'
+export type {
+  ItemAttr,
+  ItemData,
+  IItem,
+  IItems,
+  IItemResult,
+  IItemsResult
+} from './interfaces/Items'
+export type {
+  LinkAttr,
+  LinkData,
+  ILink,
+  ILinks,
+  ILinkResult,
+  ILinksResult
+} from './interfaces/Links'
+export type {
+  MenuItemAttr,
+  MenuItemData,
+  IMenuItem,
+  IMenuItems,
+  IMenuItemResult,
+  IMenuItemsResult
+} from './interfaces/MenuItems'
+export type {
+  MenuAttr,
+  MenuData,
+  IMenu,
+  IMenus,
+  IMenuResult,
+  IMenusResult
+} from './interfaces/Menus'
+export type {
+  OptionTypeAttr,
+  OptionTypeData,
+  IOptionType,
+  IOptionTypes,
+  IOptionTypeResult,
+  IOptionTypesResult
+} from './interfaces/OptionTypes'
+export type {
+  OptionValueAttr,
+  OptionValueData,
+  IOptionValue,
+  IOptionValues,
+  IOptionValueResult,
+  IOptionValuesResult
+} from './interfaces/OptionValues'
+export type {
+  OrderAttr,
+  OrderData,
+  IOrder,
+  IOrders,
+  IOrderResult,
+  IOrdersResult
+} from './interfaces/Orders'
+export type {
+  PageAttr,
+  PageData,
+  IPage,
+  IPages,
+  IPageResult,
+  IPagesResult
+} from './interfaces/Pages'
+export type {
+  PaymentMethodAttr,
+  PaymentMethodData,
+  IPaymentMethod,
+  IPaymentMethods,
+  IPaymentMethodResult,
+  IPaymentMethodsResult
+} from './interfaces/PaymentMethods'
+export type {
+  PaymentAttr,
+  PaymentData,
+  IPayment,
+  IPayments,
+  IPaymentResult,
+  IPaymentsResult
+} from './interfaces/Payments'
+export type {
+  ProductAttr,
+  ProductData,
+  IProduct,
+  IProducts,
+  IProductResult,
+  IProductsResult
+} from './interfaces/Products'
+export type {
+  PromotionActionAttr,
+  PromotionActionData,
+  IPromotionAction,
+  IPromotionActions,
+  IPromotionActionResult,
+  IPromotionActionsResult
+} from './interfaces/PromotionActions'
+export type {
+  PromotionCategoryAttr,
+  PromotionCategoryData,
+  IPromotionCategory,
+  IPromotionCategories,
+  IPromotionCategoryResult,
+  IPromotionCategoriesResult
+} from './interfaces/PromotionCategories'
+export type {
+  PromotionRuleAttr,
+  PromotionRuleData,
+  IPromotionRule,
+  IPromotionRules,
+  IPromotionRuleResult,
+  IPromotionRulesResult
+} from './interfaces/PromotionRules'
+export type {
+  PromotionAttr,
+  PromotionData,
+  IPromotion,
+  IPromotions,
+  IPromotionResult,
+  IPromotionsResult
+} from './interfaces/Promotions'
+export type {
+  RoleAttr,
+  RoleData,
+  IRole,
+  IRoles,
+  IRoleResult,
+  IRolesResult
+} from './interfaces/Roles'
+export type {
+  SectionAttr,
+  SectionData,
+  ISection,
+  ISections,
+  ISectionResult,
+  ISectionsResult
+} from './interfaces/Sections'
+export type {
+  ShipmentAttr,
+  ShipmentData,
+  IShipment,
+  IShipments,
+  IShipmentResult,
+  IShipmentsResult
+} from './interfaces/Shipments'
+export type {
+  ShippingCategoryAttr,
+  ShippingCategoryData,
+  IShippingCategory,
+  IShippingCategories,
+  IShippingCategoryResult,
+  IShippingCategoriesResult
+} from './interfaces/ShippingCategories'
+export type {
+  ShippingMethodAttr,
+  ShippingMethodData,
+  IShippingMethod,
+  IShippingMethods,
+  IShippingMethodResult,
+  IShippingMethodsResult
+} from './interfaces/ShippingMethods'
+export type {
+  StateAttr,
+  StateData,
+  IState,
+  IStates,
+  IStateResult,
+  IStatesResult
+} from './interfaces/States'
+export type {
+  StockItemAttr,
+  StockItemData,
+  IStockItem,
+  IStockItems,
+  IStockItemResult,
+  IStockItemsResult
+} from './interfaces/StockItems'
+export type {
+  StockLocationAttr,
+  StockLocationData,
+  IStockLocation,
+  IStockLocations,
+  IStockLocationResult,
+  IStockLocationsResult
+} from './interfaces/StockLocations'
+export type {
+  StoreCreditCategoryAttr,
+  StoreCreditCategoryData,
+  IStoreCreditCategory,
+  IStoreCreditCategories,
+  IStoreCreditCategoryResult,
+  IStoreCreditCategoriesResult
+} from './interfaces/StoreCreditCategories'
+export type {
+  StoreCreditAttr,
+  StoreCreditData,
+  IStoreCredit,
+  IStoreCredits,
+  IStoreCreditResult,
+  IStoreCreditsResult
+} from './interfaces/StoreCredits'
+export type {
+  StoreCreditTypeAttr,
+  StoreCreditTypeData,
+  IStoreCreditType,
+  IStoreCreditTypes,
+  IStoreCreditTypeResult,
+  IStoreCreditTypesResult
+} from './interfaces/StoreCreditTypes'
+export type {
+  TaxCategoryAttr,
+  TaxCategoryData,
+  ITaxCategory,
+  ITaxCategories,
+  ITaxCategoryResult,
+  ITaxCategoriesResult
+} from './interfaces/TaxCategories'
+export type {
+  TaxonomyAttr,
+  TaxonomyData,
+  ITaxonomy,
+  ITaxonomies,
+  ITaxonomyResult,
+  ITaxonomiesResult
+} from './interfaces/Taxonomies'
+export type {
+  TaxonAttr,
+  TaxonData,
+  ITaxon,
+  ITaxons,
+  ITaxonResult,
+  ITaxonsResult
+} from './interfaces/Taxons'
+export type {
+  TaxRateAttr,
+  TaxRateData,
+  ITaxRate,
+  ITaxRates,
+  ITaxRateResult,
+  ITaxRatesResult
+} from './interfaces/TaxRates'
+export type {
+  UserAttr,
+  UserData,
+  IUser,
+  IUsers,
+  IUserResult,
+  IUsersResult
+} from './interfaces/Users'
+export type {
+  VariantAttr,
+  VariantData,
+  IVariant,
+  IVariants,
+  IVariantResult,
+  IVariantsResult
+} from './interfaces/Variants'
+export type {
+  VendorAttr,
+  Vendor,
+  Vendors,
+  VendorResult,
+  VendorsResult
+} from './interfaces/Vendor'
+export type {
+  WebhookEventsAttr,
+  WebhookEventsData,
+  IWebhookEvents,
+  IWebhookEventsResult
+} from './interfaces/WebhookEvents'
+export type {
+  WebhookSubscriberAttr,
+  WebhookSubscriberData,
+  IWebhookSubscriber,
+  IWebhookSubscribers,
+  IWebhookSubscriberResult,
+  IWebhookSubscribersResult
+} from './interfaces/WebhookSubscribers'
+export type {
+  WishedItemAttr,
+  WishedItemData,
+  IWishedItem,
+  IWishedItems,
+  IWishedItemResult,
+  IWishedItemsResult
+} from './interfaces/WishedItems'
+export type {
+  WishlistAttr,
+  WishlistData,
+  IWishlist,
+  IWishlists,
+  IWishlistResult,
+  IWishlistsResult
+} from './interfaces/Wishlists'
+export type {
+  ZoneAttr,
+  ZoneData,
+  IZone,
+  IZones,
+  IZoneResult,
+  IZonesResult
+} from './interfaces/Zones'

--- a/packages/sdk-platform/src/interfaces/Adjustments.ts
+++ b/packages/sdk-platform/src/interfaces/Adjustments.ts
@@ -7,7 +7,7 @@ import type {
   WithCommonOptions
 } from '@spree/core-api-v2-sdk'
 
-interface AdjustmentAttr {
+export interface AdjustmentAttr {
   source_type: string
   adjustable_type: string
   amount: string

--- a/packages/sdk-platform/src/interfaces/Classifications.ts
+++ b/packages/sdk-platform/src/interfaces/Classifications.ts
@@ -7,7 +7,7 @@ import type {
   WithCommonOptions
 } from '@spree/core-api-v2-sdk'
 
-interface ClassificationAttr {
+export interface ClassificationAttr {
   position: number
   created_at: string
   updated_at: string

--- a/packages/sdk-platform/src/interfaces/Countries.ts
+++ b/packages/sdk-platform/src/interfaces/Countries.ts
@@ -7,7 +7,7 @@ import type {
   WithCommonOptions
 } from '@spree/core-api-v2-sdk'
 
-interface CountriesAttr {
+export interface CountriesAttr {
   iso_name: string
   iso: string
   iso3: string

--- a/packages/sdk-platform/src/interfaces/Digitals.ts
+++ b/packages/sdk-platform/src/interfaces/Digitals.ts
@@ -14,7 +14,7 @@ export interface DigitalAttr {
   byte_size: number
 }
 
-export interface PageData extends JsonApiDocument {
+export interface DigitalData extends JsonApiDocument {
   type: string
   id: string
   attributes: DigitalAttr
@@ -22,11 +22,11 @@ export interface PageData extends JsonApiDocument {
 }
 
 export interface IDigital extends JsonApiSingleResponse {
-  data: PageData
+  data: DigitalData
 }
 
 export interface IDigitals extends JsonApiListResponse {
-  data: PageData[]
+  data: DigitalData[]
 }
 
 export interface IDigitalResult extends ResultResponse<IDigital> {}

--- a/packages/sdk-platform/src/interfaces/Items.ts
+++ b/packages/sdk-platform/src/interfaces/Items.ts
@@ -7,7 +7,7 @@ import type {
   WithCommonOptions
 } from '@spree/core-api-v2-sdk'
 
-export interface PageAttr {
+export interface ItemAttr {
   quantity: number
   price: string
   created_at: string
@@ -43,7 +43,7 @@ export interface PageAttr {
 export interface ItemData extends JsonApiDocument {
   type: string
   id: string
-  attributes: PageAttr
+  attributes: ItemAttr
   relationships: IRelationships
 }
 

--- a/packages/sdk-platform/src/interfaces/MenuItems.ts
+++ b/packages/sdk-platform/src/interfaces/MenuItems.ts
@@ -50,7 +50,7 @@ export interface MenuItemParams {
 
 export interface MenuItemRepositionParams {
   menu_item: {
-    new_parent_id: number,
+    new_parent_id: number
     new_position_idx: number
   }
 }

--- a/packages/sdk-platform/src/interfaces/OptionTypes.ts
+++ b/packages/sdk-platform/src/interfaces/OptionTypes.ts
@@ -31,8 +31,8 @@ export interface OptionTypeData extends JsonApiDocument {
 
 export interface OptionTypeParams {
   option_type: {
-    name: 'color',
-    presentation: 'Color',
+    name: 'color'
+    presentation: 'Color'
     public_metadata?: {
       [key: string]: string
     }

--- a/packages/sdk-platform/src/interfaces/Sections.ts
+++ b/packages/sdk-platform/src/interfaces/Sections.ts
@@ -12,7 +12,7 @@ export interface SectionAttr {
   content: any
   settings: {
     gutters: string
-  },
+  }
   fit: string
   destination: string
   type: string
@@ -29,7 +29,7 @@ export interface SectionData extends JsonApiDocument {
   relationships: IRelationships
 }
 
-export interface PageParams {
+export interface SectionParams {
   cms_page: {
     name: string
     cms_page_id: string
@@ -67,12 +67,12 @@ export type ShowOptions = WithCommonOptions<
 
 export type CreateOptions = WithCommonOptions<
   { suggestToken: true; onlyAccountToken: true; suggestQuery: true },
-  PageParams
+  SectionParams
 >
 
 export type UpdateOptions = WithCommonOptions<
   { suggestToken: true; onlyAccountToken: true; suggestQuery: true },
-  PageParams & { id: string }
+  SectionParams & { id: string }
 >
 
 export type RemoveOptions = WithCommonOptions<


### PR DESCRIPTION
This PR is a platform sdk fix corresponding to the following storefront sdk PR: https://github.com/spree/spree-api-v2-js-sdk/pull/371