### PR TITLE
feat: add localized_slugs property to the platform taxons and product response

### DIFF
--- a/packages/sdk-platform/src/index.ts
+++ b/packages/sdk-platform/src/index.ts
@@ -5,3 +5,7 @@ import makeClient, { Client, Endpoints } from './makeClient'
 
 export { makeClient, endpoints, routes, platformPath }
 export type { Client, Endpoints }
+
+export type {
+  LocalizedSlugs
+} from '@spree/core-api-v2-sdk'

--- a/packages/sdk-platform/src/interfaces/Products.ts
+++ b/packages/sdk-platform/src/interfaces/Products.ts
@@ -3,6 +3,7 @@ import type {
   JsonApiListResponse,
   JsonApiSingleResponse,
   IRelationships,
+  LocalizedSlugs,
   ResultResponse,
   WithCommonOptions
 } from '@spree/core-api-v2-sdk'
@@ -31,6 +32,7 @@ export interface ProductAttr {
   currency: string
   price: string
   compare_at_price: any
+  localized_slugs: LocalizedSlugs
   public_metadata?: {
     [key: string]: string
   }

--- a/packages/sdk-platform/src/interfaces/Taxons.ts
+++ b/packages/sdk-platform/src/interfaces/Taxons.ts
@@ -3,6 +3,7 @@ import type {
   JsonApiListResponse,
   JsonApiSingleResponse,
   IRelationships,
+  LocalizedSlugs,
   ResultResponse,
   WithCommonOptions
 } from '@spree/core-api-v2-sdk'
@@ -25,6 +26,7 @@ export interface TaxonAttr {
   is_root: boolean
   is_child: boolean
   is_leaf: boolean
+  localized_slugs: LocalizedSlugs
   public_metadata?: {
     [key: string]: string
   }


### PR DESCRIPTION
This PR adds `localized_slugs` property to the response types of taxons and products in the platform sdk.